### PR TITLE
Set default port for ServiceEntry

### DIFF
--- a/pkg/skatteetaten_resourcecreator/istio/service_entry/service_entry_generator.go
+++ b/pkg/skatteetaten_resourcecreator/istio/service_entry/service_entry_generator.go
@@ -41,7 +41,7 @@ func generateServiceEntry(source resource.Source, ast *resource.Ast, key string,
 	serviceentry.Spec.Location = "MESH_EXTERNAL"
 	serviceentry.Spec.Hosts = append(serviceentry.Spec.Hosts, config.Host)
 
-	//TODO: kan denne være omnitempty i liberator?
+	//TODO: kan denne være omnitempty i liberator? Nei, men maa ha en default verdi.
 	serviceentry.Spec.Ports= []networking_istio_io_v1alpha3.Port{}
 	for _, port := range config.Ports {
 		serviceentry.Spec.Ports = append(serviceentry.Spec.Ports, networking_istio_io_v1alpha3.Port{
@@ -50,6 +50,13 @@ func generateServiceEntry(source resource.Source, ast *resource.Ast, key string,
 			Name:     port.Name,
 		})
 	}
+	// Is there a better way to set the default port for ServiceEntry?
+	if len(serviceentry.Spec.Ports) == 0 {
+		serviceentry.Spec.Ports = append(serviceentry.Spec.Ports, networking_istio_io_v1alpha3.Port{
+			Number:   443,
+			Protocol: "HTTPS",
+			Name:     "https",
+		})
+	}
 	ast.AppendOperation(resource.OperationCreateOrUpdate, &serviceentry)
-
 }

--- a/pkg/skatteetaten_resourcecreator/testdata/service_entry.yaml
+++ b/pkg/skatteetaten_resourcecreator/testdata/service_entry.yaml
@@ -40,7 +40,10 @@ tests:
             hosts:
             - ghcr.io
             location: MESH_EXTERNAL
-            ports: []
+            ports:
+              - name: https
+                number: 443
+                protocol: HTTPS
             resolution: DNS
   - operation: CreateOrUpdate
     apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
ServiceEntry configs are usually HTTPS. To simply App configuration, it makes sense to use HTTPS as
default or fallback, with the option  to add a custom ports config when neccessary.
