### PR TITLE
Deploy imagepolicy to app namespace

### DIFF
--- a/pkg/skatteetaten_resourcecreator/image_policy/imagepolicy_generator.go
+++ b/pkg/skatteetaten_resourcecreator/image_policy/imagepolicy_generator.go
@@ -64,7 +64,7 @@ func Create(app Source, ast *resource.Ast) error {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      imagePolicyName,
-			Namespace: "flux-system",
+			Namespace: app.GetNamespace(),
 		},
 		Spec: fluxcd_io_image_reflector_v1beta1.ImagePolicySpec{
 			ImageRepositoryRef: fluxcd_io_image_reflector_v1beta1.LocalObjectReference{Name: app.GetName()},

--- a/pkg/skatteetaten_resourcecreator/testdata/imagepolicy_branch.yaml
+++ b/pkg/skatteetaten_resourcecreator/testdata/imagepolicy_branch.yaml
@@ -34,7 +34,7 @@ tests:
         resource:
           metadata:
             name: myapplication-mynamespace
-            namespace: flux-system
+            namespace: mynamespace
           spec:
             filterTags:
               extract: $date$time$number

--- a/pkg/skatteetaten_resourcecreator/testdata/imagepolicy_semver.yaml
+++ b/pkg/skatteetaten_resourcecreator/testdata/imagepolicy_semver.yaml
@@ -34,7 +34,7 @@ tests:
         resource:
           metadata:
             name: myapplication-mynamespace
-            namespace: flux-system
+            namespace: mynamespace
           spec:
             imageRepositoryRef:
               name: myapplication


### PR DESCRIPTION
This is needed because ImageRepository and ImageUpdateAutomations are now deployed to app namespace to support
flux multi tenancy