### PR TITLE
Option to set subnet CIDR for NetworkPolicy

### DIFF
--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -100,6 +100,7 @@ func run() error {
 	resourceOptions.AzureSubscriptionName = cfg.Azure.SubscriptionName
 	resourceOptions.AzureSubscriptionId = cfg.Azure.SubscriptionId
 	resourceOptions.AzureDomainName = cfg.Azure.DomainName
+	resourceOptions.AzureSubnet = cfg.Azure.Subnet
 
 	mgrClient := mgr.GetClient()
 	simpleClient, err := client.New(kconfig, client.Options{

--- a/pkg/naiserator/config/config.go
+++ b/pkg/naiserator/config/config.go
@@ -105,6 +105,7 @@ type Azure struct {
 	SubscriptionName   string  `json:"subscription-name"`
 	SubscriptionId     string  `json:"subscription-id"`
 	DomainName         string  `json:"domain-name"`
+	Subnet             string  `json:"subnet"`
 }
 
 type Config struct {
@@ -182,6 +183,7 @@ const (
 	AzureSubscriptionName               = "azure.subscription-name"
 	AzureSubscriptionId                 = "azure.subscription-id"
 	AzureDomainName                     = "azure.domain-name"
+	AzureSubnet                         = "azure.subnet"
 )
 
 func bindNAIS() {
@@ -289,6 +291,7 @@ func init() {
 	flag.String(AzureSubscriptionName, "", "Name of subscription")
 	flag.String(AzureSubscriptionId, "", "UUID of subscription")
 	flag.String(AzureDomainName, "", "The postfix of the domain")
+	flag.String(AzureSubnet, "10.0.0.0/8", "The CIDR of the AKS subnet")
 }
 
 // Print out all configuration options except secret stuff.

--- a/pkg/resourcecreator/resource/options.go
+++ b/pkg/resourcecreator/resource/options.go
@@ -36,6 +36,7 @@ type Options struct {
 	AzureSubscriptionName             string
 	AzureSubscriptionId               string
 	AzureDomainName                   string
+	AzureSubnet                       string
 }
 
 // NewOptions creates a struct with the default resource options.

--- a/pkg/skatteetaten_resourcecreator/resourcecreator.go
+++ b/pkg/skatteetaten_resourcecreator/resourcecreator.go
@@ -36,7 +36,7 @@ func CreateSkatteetatenApplication(source resource.Source, resourceOptions resou
 	horizontalpodautoscaler.Create(app, ast)
 
 	if !app.Spec.UnsecureDebugDisableAllAccessPolicies {
-		network_policy.Create(app, ast)
+		network_policy.Create(app, ast, resourceOptions)
 		authorization_policy.Create(app, ast)
 	}
 

--- a/pkg/skatteetaten_resourcecreator/testdata/network_policy.yaml
+++ b/pkg/skatteetaten_resourcecreator/testdata/network_policy.yaml
@@ -3,6 +3,7 @@ config:
 
 resourceoptions:
   AzureDomainName: "mydomain"
+  AzureSubnet: "10.24.16.0/24"
 
 input:
   kind: Application
@@ -58,6 +59,7 @@ input:
           ports:
             - protocol: TCP
               port: 8888
+
 
 tests:
   - operation: CreateOrUpdate
@@ -132,7 +134,7 @@ tests:
                   - ipBlock:
                       cidr: 0.0.0.0/0
                       except:
-                        - 10.0.0.0/8
+                        - 10.24.16.0/24
                         - 172.16.0.0/12
                         - 192.168.0.0/16
               - ports:


### PR DESCRIPTION
This is needed to allow external egress to other subscriptions
and Azure resources on private network, but at the same time
restrict network access for pods inside the cluster.